### PR TITLE
fix - Update allowed prefixes in PR title check - quick

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: naveenk1223/action-pr-title@master
         with:
           regex: '-\s?([A-Z]{3}-[1-9]+|quick|release|candidate)'   #Regex the title should match.
-          allowed_prefixes: 'fonctionnalite,fix,amelioration,release,candidate'   #title should start with the given prefix
+          allowed_prefixes: 'feature,fix,release,candidate'   #title should start with the given prefix
           prefix_case_sensitive: false   #title prefix are case insensitive
           min_length: 10   #Min length of the title
           max_length: -1   #Max length of the title


### PR DESCRIPTION
This pull request updates the allowed prefixes for pull request titles in the PR title check workflow to use standardized English terms. This helps ensure consistency and clarity in PR naming conventions.

- **Workflow configuration update:**
  * [`.github/workflows/pr-title-check.yml`](diffhunk://#diff-74c9ec5ec6d2baa9f20a600129a99d613414006299bd62f2200586d7f89fb4b6L14-R14): Changed allowed PR title prefixes from French (`fonctionnalite`, `amelioration`) to English (`feature`) and removed `amelioration`.