### PR TITLE
fix - change pr rules - quick

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
       - uses: naveenk1223/action-pr-title@master
         with:
-          regex: '-\s?([A-Z]{3}-[1-9]+|quick|release|candidate)'   #Regex the title should match.
-          allowed_prefixes: 'fonctionnalite,fix,amelioration,release,candidate'   #title should start with the given prefix
+          regex: '-\s?([1-9]+|quick|release|candidate)'   #Regex the title should match.
+          allowed_prefixes: 'fonctionnalite,fix,amelioration,release,candidate,feature'   #title should start with the given prefix
           prefix_case_sensitive: false   #title prefix are case insensitive
           min_length: 10   #Min length of the title
           max_length: -1   #Max length of the title


### PR DESCRIPTION
This pull request updates the pull request title validation workflow to allow a broader range of ticket numbers and an additional allowed prefix for PR titles.

**Workflow configuration changes:**

* Relaxed the ticket number validation in the `regex` to accept any number (removing the requirement for a three-letter prefix before the number).
* Added `feature` to the list of allowed prefixes for PR titles in the `allowed_prefixes` setting.